### PR TITLE
Support servos with same id on different buses

### DIFF
--- a/build_moteus_control_example.sh
+++ b/build_moteus_control_example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-g++ -O2 -g -Wall --std=c++11 \
+g++ -O2 -g -Wall --std=c++17 \
     -Wno-psabi \
     -I lib/cpp -I /opt/vc/include -L /opt/vc/lib \
     -o moteus_control_example \

--- a/build_moteus_control_example.sh
+++ b/build_moteus_control_example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-g++ -O2 -g -Wall --std=c++17 \
+g++ -O2 -g -Wall --std=c++11 \
     -Wno-psabi \
     -I lib/cpp -I /opt/vc/include -L /opt/vc/lib \
     -o moteus_control_example \

--- a/lib/cpp/mjbots/moteus/pi3hat_moteus_interface.h
+++ b/lib/cpp/mjbots/moteus/pi3hat_moteus_interface.h
@@ -16,7 +16,6 @@
 
 #include <condition_variable>
 #include <functional>
-#include <optional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -57,7 +56,7 @@ class Pi3HatMoteusInterface {
 
   struct ServoCommand {
     int id = 0;
-    std::optional<int> bus;
+    int bus = 1;
 
     moteus::Mode mode = moteus::Mode::kStopped;
 
@@ -146,7 +145,7 @@ class Pi3HatMoteusInterface {
 
       can.expect_reply = query.any_set();
       can.id = cmd.id | (can.expect_reply ? 0x8000 : 0x0000);
-      can.bus = cmd.bus.value_or(1);
+      can.bus = cmd.bus;
       can.size = 0;
 
       moteus::WriteCanFrame write_frame(can.data, &can.size);

--- a/lib/cpp/mjbots/moteus/pi3hat_moteus_interface.h
+++ b/lib/cpp/mjbots/moteus/pi3hat_moteus_interface.h
@@ -16,6 +16,7 @@
 
 #include <condition_variable>
 #include <functional>
+#include <optional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -38,9 +39,6 @@ class Pi3HatMoteusInterface {
  public:
   struct Options {
     int cpu = -1;
-
-    // If a servo is not present, it is assumed to be on bus 1.
-    std::map<int, int> servo_bus_map;
   };
 
   Pi3HatMoteusInterface(const Options& options)
@@ -59,6 +57,7 @@ class Pi3HatMoteusInterface {
 
   struct ServoCommand {
     int id = 0;
+    std::optional<int> bus;
 
     moteus::Mode mode = moteus::Mode::kStopped;
 
@@ -71,6 +70,7 @@ class Pi3HatMoteusInterface {
 
   struct ServoReply {
     int id = 0;
+    int bus = 0;
     moteus::QueryResult result;
   };
 
@@ -146,15 +146,8 @@ class Pi3HatMoteusInterface {
 
       can.expect_reply = query.any_set();
       can.id = cmd.id | (can.expect_reply ? 0x8000 : 0x0000);
+      can.bus = cmd.bus.value_or(1);
       can.size = 0;
-
-      can.bus = [&]() {
-        const auto it = options_.servo_bus_map.find(cmd.id);
-        if (it == options_.servo_bus_map.end()) {
-          return 1;
-        }
-        return it->second;
-      }();
 
       moteus::WriteCanFrame write_frame(can.data, &can.size);
       switch (cmd.mode) {
@@ -187,6 +180,7 @@ class Pi3HatMoteusInterface {
       const auto& can = rx_can_[i];
 
       data_.replies[i].id = (can.id & 0x7f00) >> 8;
+      data_.replies[i].bus = can.bus;
       data_.replies[i].result = moteus::ParseQueryResult(can.data, can.size);
       result.query_result_size = i + 1;
     }


### PR DESCRIPTION
This is a set of changes I made in my local fork to support servos with the same ID on different buses.
- Updates `ServoReply` to include a `bus` member
- Updates `ServoCommand` to include an optional `bus` member
- Updates `moteus_control_example` to use `bus` in its commands/replies

Would you be interested in merging this change upstream? If so, what are your thoughts on:
- My use of `std::optional` requires C++17, I assume you'd like to keep this C++11-compatible?
- Do you want to maintain backwards API compatibility for `lib/cpp/mjbots/moteus/pi3hat_moteus_interface.h`?

