### PR TITLE
Add missing include to pi3hat_moteus_interface.h

### DIFF
--- a/lib/cpp/mjbots/moteus/pi3hat_moteus_interface.h
+++ b/lib/cpp/mjbots/moteus/pi3hat_moteus_interface.h
@@ -25,6 +25,7 @@
 
 #include "mjbots/pi3hat/pi3hat.h"
 
+#include "mjbots/moteus/moteus_protocol.h"
 #include "mjbots/moteus/realtime.h"
 
 namespace mjbots {


### PR DESCRIPTION
Required for `moteus::Mode`, and others.