### PR TITLE
Remove velocity command from moteus_control_example

### DIFF
--- a/lib/cpp/mjbots/moteus/moteus_control_example.cc
+++ b/lib/cpp/mjbots/moteus/moteus_control_example.cc
@@ -198,7 +198,6 @@ class SampleController {
         auto& secondary_out = output->at(1);  // We constructed this, so we know the order.
         secondary_out.mode = moteus::Mode::kPosition;
         secondary_out.position.position = secondary_initial_ + (primary_pos - primary_initial_);
-        secondary_out.position.velocity = primary.velocity;
       }
     }
   }


### PR DESCRIPTION
I find that when the example uses position/velocity control, the secondary servo will only follow the primary momentarily, if at all. Neither servo indicates a fault.

When I remove the velocity control, the secondary servo follows perfectly.
This is with moteus 4.8, pi3hat 4.4, power dist 4.3.

Happy to take this to discord if you'd prefer to discuss there!