### PR TITLE
Fixed no match operator error

### DIFF
--- a/lib/cpp/mjbots/pi3hat/pi3hat.cc
+++ b/lib/cpp/mjbots/pi3hat/pi3hat.cc
@@ -1121,7 +1121,7 @@ class Pi3Hat::Impl {
     spi->Read(cs, canbus ? 8 : 7,
               reinterpret_cast<char*>(&verify), spi_size);
     ThrowIf(
-        out != verify,
+        static_cast<DeviceCanConfiguration>(out) != verify,
         [&]() {
           return "Could not set CAN configuration properly";
         });


### PR DESCRIPTION
Hi, when using newer version of the library I've got following error:

`error: no match for ‘operator!=’ (operand types are ‘mjbots::pi3hat::{anonymous}::DeviceCanConfigurationV4’ and ‘mjbots::pi3hat::{anonymous}::DeviceCanConfiguration’)
 1124 |         out != verify,
      |         ~~~ ^~ ~~~~~~
      |         |      |
      |         |      mjbots::pi3hat::{anonymous}::DeviceCanConfiguration
      |         mjbots::pi3hat::{anonymous}::DeviceCanConfigurationV4
`

This PR fixes it by using `static_cast`.